### PR TITLE
Find line items and orders by used keys in the targeting

### DIFF
--- a/app/console
+++ b/app/console
@@ -38,6 +38,7 @@ $console->add(new Creative\Command\DeactivateAssociatedCreativesInOrderCommand($
 $console->add(new Creative\Command\CreativeCommand($app));
 $console->add(new Inventory\Command\CreateLineItemsCommand($app));
 $console->add(new Inventory\Command\KeyValuesGetterCommand($app));
+$console->add(new LineItem\Command\FindLineItemByKeyCommand($app));
 $console->add(new LineItem\Command\LineItemKeyValuesAddCommand($app));
 $console->add(new LineItem\Command\LineItemKeyValuesRemoveCommand($app));
 $console->add(new LineItem\Command\OrderLineItemsKeyValuesAddCommand($app));

--- a/src/LineItem/Command/FindLineItemByKeyCommand.php
+++ b/src/LineItem/Command/FindLineItemByKeyCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace LineItem\Command;
+
+use Inventory\Api\CustomTargetingService;
+use Inventory\Api\LineItemService;
+use Knp\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class FindLineItemByKeyCommand extends Command
+{
+	public function __construct($app, $name = null)
+	{
+		parent::__construct($name);
+	}
+
+	protected function configure()
+	{
+		$this->setName('line-items:find-by-key')
+			->setDescription('Find line items by used keys in the targeting')
+			->addArgument('keys', InputArgument::REQUIRED, 'Keys (separated with comma');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output)
+	{
+		$customTargetingService = new CustomTargetingService();
+		$lineItemService = new LineItemService();
+
+		$keys = explode(',', $input->getArgument('keys'));
+
+		$keyIds = $customTargetingService->getKeyIds($keys);
+
+		$lineItems = $lineItemService->findLineItemIdsByKeys($keyIds);
+
+		foreach ($lineItems as $lineItem) {
+			printf(" - order: %s, line item: %s\n", $lineItem['order_id'], $lineItem['line_item_id']);
+		}
+	}
+}
+


### PR DESCRIPTION
Usage:
```
./app/console line-items:find-by-key provider,requestSource,shield,sp.block
```
```
./app/console line-items:find-by-key PM_Rubicon,rpfl_7450,Rubicon_Deal_id,amznslots,ox160x600,ox300x250,ox300x600,ox320x50,ox728x90,ox970x250,oxslots
```