### PR TITLE
run container as numeric user

### DIFF
--- a/k8s-cron-jobs/Dockerfile
+++ b/k8s-cron-jobs/Dockerfile
@@ -1,13 +1,11 @@
 FROM php:7.3-alpine
 COPY --from=composer:1.8.6 /usr/bin/composer /usr/bin/composer
 
-RUN addgroup -S maka && adduser -S maka -G maka
-
 RUN apk add libxml2-dev
 RUN docker-php-ext-install soap
 RUN docker-php-ext-enable soap
 
-RUN mkdir /home/maka/dfp-query-tool
+RUN mkdir -p /home/maka/dfp-query-tool
 WORKDIR /home/maka/dfp-query-tool
 RUN mkdir line-item-presets log config
 RUN touch config/queries.yml
@@ -17,7 +15,7 @@ COPY app app
 COPY config/db.sample.yml /home/maka/dfp-query-tool/config/db.yml
 COPY k8s-cron-jobs/approve.sh approve.sh
 COPY src src
-RUN chown -R maka:maka /home/maka/dfp-query-tool
+RUN chown -R 65534:65534 /home/maka/dfp-query-tool
 RUN chmod +x approve.sh
-USER maka
+USER 65534
 RUN composer install


### PR DESCRIPTION
Use numeric container user so that k8s could verify if user is non-root. It's required for pod security policy on our k8s clusters.